### PR TITLE
Provide ability to lookup Place Details by a placeId from a Prediction

### DIFF
--- a/src/main/java/se/walkercrou/places/GooglePlacesInterface.java
+++ b/src/main/java/se/walkercrou/places/GooglePlacesInterface.java
@@ -221,6 +221,11 @@ public interface GooglePlacesInterface extends Types, Statuses {
     public static final String STRING_ID = "id";
 
     /**
+     * The unique identifier for retrieving information about a place
+     */
+    public static final String STRING_PLACE_ID = "place_id";
+
+    /**
      * Url to the icon to represent this place
      */
     public static final String STRING_ICON = "icon";

--- a/src/main/java/se/walkercrou/places/Place.java
+++ b/src/main/java/se/walkercrou/places/Place.java
@@ -25,6 +25,7 @@ public class Place {
     private final List<AddressComponent> addressComponents = new ArrayList<>();
     private GooglePlaces client;
     private String id;
+    private String placeId;
     private double lat = -1, lng = -1;
     private JSONObject json;
     private String iconUrl;
@@ -79,6 +80,7 @@ public class Place {
 
         // easy stuff
         String id = result.getString(STRING_ID);
+        String placeId = result.getString(STRING_PLACE_ID);
         String name = result.getString(STRING_NAME);
         String address = result.optString(STRING_ADDRESS, null);
         String phone = result.optString(STRING_PHONE_NUMBER, null);
@@ -241,7 +243,7 @@ public class Place {
                 .setReferenceId(reference).setStatus(status).setVicinity(vicinity).setPhoneNumber(phone)
                 .setInternationalPhoneNumber(internationalPhone).setGoogleUrl(url).setWebsite(website)
                 .addPhotos(photos).addAddressComponents(addressComponents).setHours(schedule).addReviews(reviews)
-                .setUtcOffset(utcOffset).setJson(result);
+                .setPlaceId(placeId).setUtcOffset(utcOffset).setJson(result);
     }
 
     /**
@@ -281,6 +283,26 @@ public class Place {
      */
     protected Place setId(String id) {
         this.id = id;
+        return this;
+    }
+
+    /**
+     * Returns the unique place id for retrieving information about this place.
+     *
+     * @return placeId
+     */
+    public String getPlaceId() {
+        return placeId;
+    }
+
+    /**
+     * Sets the unique place id for retrieving information about this place.
+     *
+     * @param placeId placeId
+     * @return this
+     */
+    protected Place setPlaceId(String placeId) {
+        this.placeId = placeId;
         return this;
     }
 

--- a/src/main/java/se/walkercrou/places/Prediction.java
+++ b/src/main/java/se/walkercrou/places/Prediction.java
@@ -17,7 +17,7 @@ public class Prediction {
     private final List<DescriptionTerm> terms = new ArrayList<>();
     private final List<String> types = new ArrayList<>();
     private GooglePlaces client;
-    private String placeId, placeReference;
+    private String id, placeId, placeReference;
     private String description;
     private int substrOffset, substrLength;
 
@@ -42,6 +42,7 @@ public class Prediction {
             String description = jsonPrediction.getString(GooglePlaces.STRING_DESCRIPTION);
             String id = jsonPrediction.optString(GooglePlaces.STRING_ID, null);
             String reference = jsonPrediction.optString(GooglePlaces.STRING_REFERENCE, null);
+            String placeId = jsonPrediction.optString(GooglePlaces.STRING_PLACE_ID, null);
 
             JSONArray jsonTerms = jsonPrediction.getJSONArray(GooglePlaces.ARRAY_TERMS);
             List<DescriptionTerm> terms = new ArrayList<>();
@@ -65,7 +66,7 @@ public class Prediction {
             int substrOffset = substr.getInt(GooglePlaces.INTEGER_OFFSET);
             int substrLength = substr.getInt(GooglePlaces.INTEGER_LENGTH);
 
-            predictions.add(new Prediction().setDescription(description).setPlaceId(id)
+            predictions.add(new Prediction().setDescription(description).setId(id).setPlaceId(placeId)
                     .setPlaceReference(reference).addTerms(terms).addTypes(types).setSubstringLength(substrLength)
                     .setSubstringOffset(substrOffset).setClient(client));
         }
@@ -181,7 +182,21 @@ public class Prediction {
     /**
      * Returns the id of the place this prediction is suggesting.
      *
-     * @return place id
+     * @return id
+     */
+    public String getId() {
+        return id;
+    }
+
+    protected Prediction setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Returns the placeId of the place this prediction is suggesting.
+     *
+     * @return placeId
      */
     public String getPlaceId() {
         return placeId;


### PR DESCRIPTION
- Places API has deprecated id and reference. They are replaced by place ID
- Prediction: added placeId
  - getPlaceId() now returns placeId (instead of id).
  - getId() returns id
  - clients that rely on the old behavior should replace getPlaceId() with getId()
- GooglePlacesInterface: added STRING_PLACE_ID
- Place: placeId is parsed from json