### PR TITLE
Locale.ENGLISH must be set for latitude/longitude/radius params

### DIFF
--- a/src/main/java/se/walkercrou/places/GooglePlaces.java
+++ b/src/main/java/se/walkercrou/places/GooglePlaces.java
@@ -226,7 +226,7 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getNearbyPlaces(double lat, double lng, double radius, int limit, Param... extraParams) {
         try {
-            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format("key=%s&location=%f,%f&radius=%f",
+            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&radius=%f",
                     apiKey, lat, lng, radius), extraParams);
             return getPlaces(uri, METHOD_NEARBY_SEARCH, limit);
         } catch (Exception e) {
@@ -258,7 +258,7 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getPlacesByRadar(double lat, double lng, double radius, int limit, Param... extraParams) {
         try {
-            String uri = buildUrl(METHOD_RADAR_SEARCH, String.format("key=%s&location=%f,%f&radius=%f",
+            String uri = buildUrl(METHOD_RADAR_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&radius=%f",
                     apiKey, lat, lng, radius), extraParams);
             return getPlaces(uri, METHOD_RADAR_SEARCH, limit);
         } catch (Exception e) {


### PR DESCRIPTION
In certain language the '.' is replace by a ',' which will cause invalid parameters on the URL.