### PR TITLE
Adds extra check to prevent sleep(3000) call on last page of results

### DIFF
--- a/src/main/java/se/walkercrou/places/GooglePlaces.java
+++ b/src/main/java/se/walkercrou/places/GooglePlaces.java
@@ -394,7 +394,8 @@ public class GooglePlaces implements GooglePlacesInterface {
             String raw = requestHandler.get(uri);
             debug(raw);
             String nextPage = parse(this, places, raw, limit);
-            if (nextPage != null) {
+            // reduce the limit, update the uri and wait for token, but only if there are more pages to read
+            if (nextPage != null && i < pages - 1) {
                 limit -= MAXIMUM_PAGE_RESULTS;
                 uri = String.format("%s%s/json?pagetoken=%s&key=%s",
                         API_URL, method, nextPage, apiKey);


### PR DESCRIPTION
Currently the code checks to see if a next page is available before deciding to wait on the token to get the next page. This commit just adds another check to ensure that you actually want more results (regardless of whether or not they're available). If we've already gotten all the pages that were requested, don't wait, just return. This improves performance in the case where you only need, say, 10 results back.