### PR TITLE
Correctly format lat, lng and radius parameters when server is not english configured.

### DIFF
--- a/src/main/java/se/walkercrou/places/GooglePlaces.java
+++ b/src/main/java/se/walkercrou/places/GooglePlaces.java
@@ -217,8 +217,8 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getNearbyPlaces(double lat, double lng, double radius, int limit, Param... extraParams) {
         try {
-            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&radius=%f",
-                    apiKey, lat, lng, radius), extraParams);
+            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%s,%s&radius=%s",
+                    apiKey, String.valueOf(lat), String.valueOf(lng), String.valueOf(radius)), extraParams);
             return getPlaces(uri, METHOD_NEARBY_SEARCH, limit);
         } catch (Exception e) {
             throw new GooglePlacesException(e);
@@ -233,8 +233,8 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getNearbyPlacesRankedByDistance(double lat, double lng, int limit, Param... params) {
         try {
-            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&rankby=distance",
-                    apiKey, lat, lng), params);
+            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%s,%s&rankby=distance",
+                    apiKey, String.valueOf(lat), String.valueOf(lng)), params);
             return getPlaces(uri, METHOD_NEARBY_SEARCH, limit);
         } catch (Exception e) {
             throw new GooglePlacesException(e);


### PR DESCRIPTION
in a not english server, the String.format can encode the double with a
fractional separator other than . (dot). 
In French, for example, it's  a coma (,).

So I just used String.valueOf() method to correctly encode the double values always with a dot separator.