### PR TITLE
Correctly format lat, lng and radius parameters when server is not english configured (with tests)

### DIFF
--- a/src/main/java/se/walkercrou/places/GooglePlaces.java
+++ b/src/main/java/se/walkercrou/places/GooglePlaces.java
@@ -217,8 +217,8 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getNearbyPlaces(double lat, double lng, double radius, int limit, Param... extraParams) {
         try {
-            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&radius=%f",
-                    apiKey, lat, lng, radius), extraParams);
+            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%s,%s&radius=%s",
+                    apiKey, String.valueOf(lat), String.valueOf(lng), String.valueOf(radius)), extraParams);
             return getPlaces(uri, METHOD_NEARBY_SEARCH, limit);
         } catch (Exception e) {
             throw new GooglePlacesException(e);
@@ -233,8 +233,8 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getNearbyPlacesRankedByDistance(double lat, double lng, int limit, Param... params) {
         try {
-            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&rankby=distance",
-                    apiKey, lat, lng), params);
+            String uri = buildUrl(METHOD_NEARBY_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%s,%s&rankby=distance",
+                    apiKey, String.valueOf(lat), String.valueOf(lng)), params);
             return getPlaces(uri, METHOD_NEARBY_SEARCH, limit);
         } catch (Exception e) {
             throw new GooglePlacesException(e);

--- a/src/test/java/se/walkercrou/places/GooglePlacesTest.java
+++ b/src/test/java/se/walkercrou/places/GooglePlacesTest.java
@@ -34,7 +34,7 @@ public class GooglePlacesTest {
     public void testGetNearbyPlacesRankedByDistance() {
         System.out.println("******************** getNearbyPlacesRankedByDistance ********************");
         if (!findPlace(google.getNearbyPlaces(TEST_PLACE_LAT, TEST_PLACE_LNG, MAXIMUM_RADIUS,
-                MAXIMUM_RESULTS), TEST_PLACE_NAME))
+                MAXIMUM_RESULTS, TypeParam.name("types").value(Types.TYPE_UNIVERSITY)), TEST_PLACE_NAME))
             fail("Test place could not be found at coordinates.");
 
         if (!hasAtLeastAPlace(google.getNearbyPlacesRankedByDistance(TEST_PLACE_LAT, TEST_PLACE_LNG, MAXIMUM_RESULTS,
@@ -48,7 +48,7 @@ public class GooglePlacesTest {
     public void testGetNearbyPlaces() {
         System.out.println("******************** getNearbyPlaces ********************");
         if (!findPlace(google.getNearbyPlaces(TEST_PLACE_LAT, TEST_PLACE_LNG, MAXIMUM_RADIUS,
-                MAXIMUM_RESULTS), TEST_PLACE_NAME))
+                MAXIMUM_RESULTS, TypeParam.name("types").value(Types.TYPE_UNIVERSITY)), TEST_PLACE_NAME))
             fail("Test place could not be found at coordinates.");
 
         if (!hasAtLeastAPlace(google.getNearbyPlaces(TEST_PLACE_LAT, TEST_PLACE_LNG, MAXIMUM_RADIUS,

--- a/src/test/java/se/walkercrou/places/ProtocolTests.java
+++ b/src/test/java/se/walkercrou/places/ProtocolTests.java
@@ -39,7 +39,7 @@ public class ProtocolTests {
     @Test
     public void testNearbySearch() {
         System.out.println("---- Nearby Search ---");
-        List<Place> places = google.getNearbyPlaces(UVM_LAT, UVM_LNG, MAXIMUM_RADIUS);
+        List<Place> places = google.getNearbyPlaces(UVM_LAT, UVM_LNG, MAXIMUM_RADIUS, TypeParam.name("types").value(Types.TYPE_UNIVERSITY));
         assertContainsPlace(places, UVM_NAME);
         testTextSearch();
     }


### PR DESCRIPTION
in a not english server, the String.format can encode the double with a
fractional separator other than . (dot). 
In French, for example, it's a coma (,).

So I just used String.valueOf() method to correctly encode the double values always with a dot separator.

Also, the tests failed because the default nearby query answers doesn't include University of Vermont.
I changes the query, adding a university type in it to restrict the answers and be sure University of Vermont is part of the returned places.