### PR TITLE
Read places api key from Environment Variables in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.idea/
 /out/
 .DS_Store
+
+places_api.key

--- a/src/main/resources/places_api.key
+++ b/src/main/resources/places_api.key
@@ -1,1 +1,0 @@
-${env.GOOGLE_PLACES_API_KEY}

--- a/src/main/resources/places_api.key.example
+++ b/src/main/resources/places_api.key.example
@@ -1,0 +1,1 @@
+${env.GOOGLE_PLACES_API_KEY}

--- a/src/test/java/se/walkercrou/places/GooglePlacesTest.java
+++ b/src/test/java/se/walkercrou/places/GooglePlacesTest.java
@@ -1,5 +1,6 @@
 package se.walkercrou.places;
 
+import java.io.File;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -7,6 +8,7 @@ import org.junit.Test;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
 
 import static org.junit.Assert.fail;
 import static se.walkercrou.places.GooglePlaces.*;
@@ -20,12 +22,10 @@ public class GooglePlacesTest {
     @Before
     public void setUp() {
         try {
-            InputStream in = GooglePlacesTest.class.getResourceAsStream("/" + API_KEY_FILE_NAME);
-            String apiKey = null;
-            if (in == null) {
-                apiKey = System.getenv("GOOGLE_PLACES_API_KEY");
-            } else {
-                apiKey = IOUtils.toString(in);
+            String apiKey = System.getenv("GOOGLE_PLACES_API_KEY");
+            if (apiKey == null || "".equals(apiKey)) {
+                File file = new File(GooglePlacesTest.class.getResource("/" + API_KEY_FILE_NAME).getFile());
+                apiKey = FileUtils.readFileToString(file).replace("\n", "").replace("\r", "");
             }
             google = new GooglePlaces(apiKey);
             google.setDebugModeEnabled(true);

--- a/src/test/java/se/walkercrou/places/GooglePlacesTest.java
+++ b/src/test/java/se/walkercrou/places/GooglePlacesTest.java
@@ -21,9 +21,13 @@ public class GooglePlacesTest {
     public void setUp() {
         try {
             InputStream in = GooglePlacesTest.class.getResourceAsStream("/" + API_KEY_FILE_NAME);
-            if (in == null)
-                throw new RuntimeException("API key not found.");
-            google = new GooglePlaces(IOUtils.toString(in));
+            String apiKey = null;
+            if (in == null) {
+                apiKey = System.getenv("GOOGLE_PLACES_API_KEY");
+            } else {
+                apiKey = IOUtils.toString(in);
+            }
+            google = new GooglePlaces(apiKey);
             google.setDebugModeEnabled(true);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Try to read places api key from Environment Variables in tests before read it from places_api.key.

This allow build in travis without add the places_api.key file.