### PR TITLE
Google has discontinued Radar Search and should be removed for librar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ projects, please consider donating a small amount so that I may continue to devo
 * [Place Searches](#place-searches)
     * [Nearby Search](#nearby-search-requests)
     * [Text Search](#text-search-requests)
-    * [Radar Search](#radar-search-requests)
     * [Adding extra URL parameters](#additional-url-parameters)
 * [Place Details](#place-details)
     * [Icons](#icons)
@@ -103,14 +102,6 @@ You can also search for locations by search query. This is the same backend syst
 
 ```java
 List<Place> places = client.getPlacesByQuery("Empire State Building", GooglePlaces.MAXIMUM_RESULTS);
-```
-
-### Radar Search Requests
-
-You can also use the ["radar"](https://developers.google.com/places/documentation/search#RadarSearchRequests) method of finding locations.
-
-```java
-List<Place> places = client.getPlacesByRadar(lat, lng, radius, GooglePlaces.MAXIMUM_RESULTS);
 ```
 
 ### Additional Url Parameters

--- a/src/main/java/se/walkercrou/places/GooglePlaces.java
+++ b/src/main/java/se/walkercrou/places/GooglePlaces.java
@@ -102,27 +102,6 @@ public class GooglePlaces implements GooglePlacesInterface {
 
         return json.optString(STRING_NEXT_PAGE_TOKEN, null);
     }
-    
-    /**
-     * Parses the specified Radar raw json String into a list of places.
-     *
-     * @param places to parse into
-     * @param str    Radar raw json
-     * @param limit  the maximum amount of places to return
-     */
-    public static void parseRadar(GooglePlaces client, List<Place> places, String str, int limit) {
-      // parse json
-      JSONObject json = new JSONObject(str);
-      
-      // check root elements
-      String statusCode = json.getString(STRING_STATUS);
-      checkStatus(statusCode, json.optString(STRING_ERROR_MESSAGE));
-      if (statusCode.equals(STATUS_ZERO_RESULTS))
-        return;
-      
-      JSONArray results = json.getJSONArray(ARRAY_RESULTS);
-      parseResults(client, places, results, Math.min(limit, MAXIMUM_RADAR_RESULTS));
-    }
 
     private static void parseResults(GooglePlaces client, List<Place> places, JSONArray results, int limit) {
         for (int i = 0; i < limit; i++) {
@@ -260,22 +239,6 @@ public class GooglePlaces implements GooglePlacesInterface {
     @Override
     public List<Place> getPlacesByQuery(String query, Param... extraParams) {
         return getPlacesByQuery(query, DEFAULT_RESULTS, extraParams);
-    }
-
-    @Override
-    public List<Place> getPlacesByRadar(double lat, double lng, double radius, int limit, Param... extraParams) {
-        try {
-            String uri = buildUrl(METHOD_RADAR_SEARCH, String.format(Locale.ENGLISH, "key=%s&location=%f,%f&radius=%f",
-                    apiKey, lat, lng, radius), extraParams);
-            return getRadarPlaces(uri, METHOD_RADAR_SEARCH, limit);
-        } catch (Exception e) {
-            throw new GooglePlacesException(e);
-        }
-    }
-
-    @Override
-    public List<Place> getPlacesByRadar(double lat, double lng, double radius, Param... extraParams) {
-        return getPlacesByRadar(lat, lng, radius, MAXIMUM_RESULTS, extraParams);
     }
 
     @Override
@@ -433,17 +396,6 @@ public class GooglePlaces implements GooglePlacesInterface {
         }
 
         return places;
-    }
-
-    private List<Place> getRadarPlaces(String uri, String method, int limit) throws IOException {
-      limit = Math.min(limit, MAXIMUM_RADAR_RESULTS); // max of 200 results possible
-
-      List<Place> places = new ArrayList<>();
-      String raw = requestHandler.get(uri);
-      debug(raw);
-      parseRadar(this, places, raw, limit);
-
-      return places;
     }
 
     private void sleep(long millis) {

--- a/src/main/java/se/walkercrou/places/GooglePlacesInterface.java
+++ b/src/main/java/se/walkercrou/places/GooglePlacesInterface.java
@@ -29,11 +29,6 @@ public interface GooglePlacesInterface extends Types, Statuses {
      * The maximum results that can be returned.
      */
     int MAXIMUM_RESULTS = 60;
-    
-    /**
-     * The maximum radar results that can be returned.
-     */
-    int MAXIMUM_RADAR_RESULTS = 200;
 
     /**
      * The maximum search radius for places.
@@ -43,7 +38,6 @@ public interface GooglePlacesInterface extends Types, Statuses {
     // METHODS
     String METHOD_NEARBY_SEARCH = "nearbysearch";
     String METHOD_TEXT_SEARCH = "textsearch";
-    String METHOD_RADAR_SEARCH = "radarsearch";
     String METHOD_DETAILS = "details";
     String METHOD_ADD = "add";
     String METHOD_DELETE = "delete";
@@ -452,33 +446,6 @@ public interface GooglePlacesInterface extends Types, Statuses {
      * @return a list of places that were found
      */
     List<Place> getPlacesByQuery(String query, Param... extraParams);
-
-    /**
-     * Returns the places at the specified latitude and longitude according to the "radar" method specified by Google
-     * Places API.  If the specified limit is greater than {@link #MAXIMUM_PAGE_RESULTS}, multiple HTTP GET requests
-     * may be made if necessary.
-     *
-     * @param lat         latitude
-     * @param lng         longitude
-     * @param radius      radius
-     * @param limit       the maximum amount of places to return
-     * @param extraParams any extra parameters to include in the request URL
-     * @return a list of places that were found
-     */
-    List<Place> getPlacesByRadar(double lat, double lng, double radius, int limit, Param... extraParams);
-
-    /**
-     * Returns the places at the specified latitude and longitude according to the "radar" method specified by Google
-     * Places API. No more than {@link #DEFAULT_RESULTS} will be returned and no more than one HTTP GET request will
-     * be sent.
-     *
-     * @param lat         latitude
-     * @param lng         longitude
-     * @param radius      radius
-     * @param extraParams any extra parameters to include in the request URL
-     * @return a list of places that were found
-     */
-    List<Place> getPlacesByRadar(double lat, double lng, double radius, Param... extraParams);
 
     /**
      * Returns the place specified by the 'placeid'.

--- a/src/test/java/se/walkercrou/places/GooglePlacesTest.java
+++ b/src/test/java/se/walkercrou/places/GooglePlacesTest.java
@@ -62,20 +62,6 @@ public class GooglePlacesTest {
         System.out.println("******************** getPlacesByQuery ********************");
         if (!findPlace(google.getPlacesByQuery(TEST_PLACE_NAME, MAXIMUM_RESULTS), TEST_PLACE_NAME))
             fail("Test place could not be found by name");
-        testGetPlacesByRadar();
-    }
-
-    public void testGetPlacesByRadar() {
-        System.out.println("******************** getPlacesByRadar ********************");
-        List<Place> places = google.getPlacesByRadar(TEST_PLACE_LAT, TEST_PLACE_LNG, MAXIMUM_RADIUS,
-                MAXIMUM_RESULTS, Param.name("name").value(TEST_PLACE_NAME));
-        boolean found = false;
-        for (Place place : places) {
-            if (place.getDetails().getName().equals(TEST_PLACE_NAME))
-                found = true;
-        }
-        if (!found)
-            fail("Test place could not be found using the radar method.");
     }
 
     private boolean findPlace(List<Place> places, String name) {


### PR DESCRIPTION
Google has discontinued Radar Search and should be removed for library and tests as the call will always fail now. 

Reference URL: https://cloud.google.com/blog/products/maps-platform/announcing-deprecation-of-place-add
